### PR TITLE
Enable building remotely with BuildBuddy

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -94,18 +94,15 @@ build:release --stamp -c opt --copt=-gmlt
 # Use the RBE instance in the kythe-repo project
 build:remote --remote_instance_name=projects/kythe-repo/instances/default_instance --bes_instance_name=kythe-repo
 
-build:remote --google_default_credentials=true
 build:remote --jobs=50
 build:remote --remote_timeout=3600
-build:remote --remote_cache=grpcs://remotebuildexecution.googleapis.com
-build:remote --remote_executor=grpcs://remotebuildexecution.googleapis.com
+build:remote --remote_executor=grpcs://buildbuddy.buildbuddy.io
 # Avoid fetching unnecessary intermediate files locally.
 build:remote --remote_download_toplevel
 
-# TODO(schroederc): add buildeventservice
-# build:remote --bes_backend="buildeventservice.googleapis.com"
-# build:remote --bes_timeout=60s
-# build:remote --bes_results_url="https://source.cloud.google.com/results/invocations/"
+build:remote --bes_backend=grpcs://buildbuddy.buildbuddy.io
+build:remote --bes_timeout=60s
+build:remote --bes_results_url=https://app.buildbuddy.io/invocation/
 
 # Starting with Bazel 0.27.0 strategies do not need to be explicitly
 # # defined. See https://github.com/bazelbuild/bazel/issues/7480

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -13,37 +13,26 @@
 # limitations under the License.
 
 # docker build -t gcr.io/kythe-repo/kythe-builder .
-FROM ubuntu:xenial
+FROM ubuntu:24.04
 
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y --no-install-recommends curl ca-certificates && \
     apt-get clean
 
-RUN echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list
-RUN curl https://bazel.build/bazel-release.pub.gpg | apt-key add -
-
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
       git pkg-config zip unzip rsync patch zsh wget net-tools less parallel locales make \
-      g++ gcc openjdk-8-jdk openjdk-8-source clang-3.6 flex asciidoc source-highlight graphviz \
-      zlib1g-dev libarchive-dev uuid-dev bazel \
+      g++ gcc openjdk-21-jdk openjdk-21-source clang-15 flex asciidoc source-highlight graphviz \
+      zlib1g-dev libarchive-dev uuid-dev golang bison \
       ca-certificates-java libsasl2-dev && \
     apt-get clean
 
-RUN update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
-ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
-ENV CC=/usr/bin/clang-3.6
-
-# Bison
-RUN wget http://archive.kernel.org/debian-archive/debian/pool/main/b/bison/bison_2.3.dfsg-5_amd64.deb -O /tmp/bison_2.3.deb && \
-    dpkg -i /tmp/bison_2.3.deb && \
-    rm -f /tmp/bison_2.3.deb
+RUN update-alternatives --set java /usr/lib/jvm/java-21-openjdk-amd64/bin/java
+ENV JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64
+ENV CC=/usr/bin/clang-15
 
 # Go
-RUN wget https://storage.googleapis.com/golang/go1.4.linux-amd64.tar.gz -O /tmp/go.tar.gz && \
-    tar xzf /tmp/go.tar.gz -C /usr/local/ && \
-    rm -f /tmp/go.tar.gz
-ENV PATH=/usr/local/go/bin:$PATH
+ENV PATH=/root/go/bin:$PATH

--- a/tools/platforms/configs/rbe_default/cc/BUILD
+++ b/tools/platforms/configs/rbe_default/cc/BUILD
@@ -15,7 +15,6 @@
 # This becomes the BUILD file for @local_config_cc// under non-BSD unixes.
 
 load(":cc_toolchain_config.bzl", "cc_toolchain_config")
-load(":armeabi_cc_toolchain_config.bzl", "armeabi_cc_toolchain_config")
 load("@rules_cc//cc:defs.bzl", "cc_toolchain", "cc_toolchain_suite")
 
 package(default_visibility = ["//visibility:public"])
@@ -41,19 +40,6 @@ filegroup(
     srcs = glob(["extra_tools/**"], allow_empty = True) + [":builtin_include_directory_paths"],
 )
 
-# This is the entry point for --crosstool_top.  Toolchains are found
-# by lopping off the name of --crosstool_top and searching for
-# the "${CPU}" entry in the toolchains attribute.
-cc_toolchain_suite(
-    name = "toolchain",
-    toolchains = {
-        "k8|clang": ":cc-compiler-k8",
-        "k8": ":cc-compiler-k8",
-        "armeabi-v7a|compiler": ":cc-compiler-armeabi-v7a",
-        "armeabi-v7a": ":cc-compiler-armeabi-v7a",
-    },
-)
-
 cc_toolchain(
     name = "cc-compiler-k8",
     toolchain_identifier = "linux_gnu_x86",
@@ -73,23 +59,24 @@ cc_toolchain(
 cc_toolchain_config(
     name = "linux_gnu_x86",
     cpu = "k8",
-    compiler = "clang",
+    compiler = "compiler",
     toolchain_identifier = "linux_gnu_x86",
     host_system_name = "i686-unknown-linux-gnu",
     target_system_name = "x86_64-unknown-linux-gnu",
-    target_libc = "glibc_2.19",
+    target_libc = "glibc_2.39",
     abi_version = "clang",
-    abi_libc_version = "glibc_2.19",
-    cxx_builtin_include_directories = ["/usr/lib/llvm-15/lib/clang/15.0.7/include",
-    "/usr/local/include",
-    "/usr/include/x86_64-linux-gnu",
-    "/usr/include",
-    "/usr/lib/llvm-15/lib/clang/15.0.7/share",
-    "/usr/include/c++/12",
-    "/usr/include/x86_64-linux-gnu/c++/12",
-    "/usr/include/c++/12/backward",
-    "/usr/lib/llvm-15/include/c++/v1"],
-    tool_paths = {"ar": "/usr/bin/ar",
+    abi_libc_version = "glibc_2.39",
+    cxx_builtin_include_directories = [
+        "/usr/include",
+        "/usr/include/c++/13",
+        "/usr/include/c++/13/backward",
+        "/usr/include/x86_64-linux-gnu",
+        "/usr/include/x86_64-linux-gnu/c++/13",
+        "/usr/lib/llvm-15/lib/clang/15.0.7/include",
+        "/usr/local/include",
+    ],
+    tool_paths = {
+        "ar": "/usr/bin/ar",
         "ld": "/usr/bin/ld",
         "llvm-cov": "None",
         "llvm-profdata": "None",
@@ -100,54 +87,44 @@ cc_toolchain_config(
         "nm": "/usr/bin/nm",
         "objcopy": "/usr/bin/objcopy",
         "objdump": "/usr/bin/objdump",
-        "strip": "/usr/bin/strip"},
-    compile_flags = ["-fstack-protector",
-    "-Wall",
-    "-Wthread-safety",
-    "-Wself-assign",
-    "-Wunused-but-set-parameter",
-    "-Wno-free-nonheap-object",
-    "-fcolor-diagnostics",
-    "-fno-omit-frame-pointer"],
-    opt_compile_flags = ["-g0",
-    "-O2",
-    "-D_FORTIFY_SOURCE=1",
-    "-DNDEBUG",
-    "-ffunction-sections",
-    "-fdata-sections"],
+        "strip": "/usr/bin/strip"
+    },
+    compile_flags = [
+        "-fstack-protector",
+        "-Wall",
+        "-Wthread-safety",
+        "-Wself-assign",
+        "-Wunused-but-set-parameter",
+        "-Wno-free-nonheap-object",
+        "-fcolor-diagnostics",
+        "-fno-omit-frame-pointer"
+    ],
+    opt_compile_flags = [
+        "-g0",
+        "-O2",
+        "-D_FORTIFY_SOURCE=1",
+        "-DNDEBUG",
+        "-ffunction-sections",
+        "-fdata-sections"
+    ],
     dbg_compile_flags = ["-g"],
     cxx_flags = ["-std=c++14"],
-    link_flags = ["-fuse-ld=/usr/bin/ld.gold",
-    "-Wl,-no-as-needed",
-    "-Wl,-z,relro,-z,now",
-    "-B/usr/lib/llvm-15/bin"],
-    link_libs = ["-lstdc++",
-    "-lm"],
+    link_flags = [
+        "-fuse-ld=/usr/bin/ld.gold",
+        "-Wl,-no-as-needed",
+        "-Wl,-z,relro,-z,now",
+        "-B/usr/lib/llvm-15/bin",
+    ],
+    link_libs = ["-lstdc++", "-lm"],
     opt_link_flags = ["-Wl,--gc-sections"],
-    unfiltered_compile_flags = ["-no-canonical-prefixes",
-    "-Wno-builtin-macro-redefined",
-    "-D__DATE__=\"redacted\"",
-    "-D__TIMESTAMP__=\"redacted\"",
-    "-D__TIME__=\"redacted\""],
+    unfiltered_compile_flags = [
+        "-no-canonical-prefixes",
+        "-Wno-builtin-macro-redefined",
+        "-D__DATE__=\"redacted\"",
+        "-D__TIMESTAMP__=\"redacted\"",
+        "-D__TIME__=\"redacted\""
+    ],
     coverage_compile_flags = ["--coverage"],
     coverage_link_flags = ["--coverage"],
     supports_start_end_lib = True,
 )
-
-# Android tooling requires a default toolchain for the armeabi-v7a cpu.
-cc_toolchain(
-    name = "cc-compiler-armeabi-v7a",
-    toolchain_identifier = "stub_armeabi-v7a",
-    toolchain_config = ":stub_armeabi-v7a",
-    all_files = ":empty",
-    ar_files = ":empty",
-    as_files = ":empty",
-    compiler_files = ":empty",
-    dwp_files = ":empty",
-    linker_files = ":empty",
-    objcopy_files = ":empty",
-    strip_files = ":empty",
-    supports_param_files = 1,
-)
-
-armeabi_cc_toolchain_config(name = "stub_armeabi-v7a")

--- a/tools/platforms/configs/rbe_default/config/BUILD
+++ b/tools/platforms/configs/rbe_default/config/BUILD
@@ -42,7 +42,7 @@ platform(
         "@bazel_tools//tools/cpp:clang",
     ],
     exec_properties = {
-        "container-image": "docker://gcr.io/kythe-repo/kythe-builder@sha256:c61738bd4708422634b7d45093a3632fb150fc5b29a8d582d86ce9c8915c1d22",
+        "container-image": "docker://ghcr.io/sluongng/kythe:24.04@sha256:587262c97084c4ca7a5f0ba35943119c62419128053dff0391bc5db7f31f6682",
         "OSFamily": "Linux",
     },
 )

--- a/tools/platforms/configs/rbe_default/java/BUILD
+++ b/tools/platforms/configs/rbe_default/java/BUILD
@@ -26,6 +26,6 @@ alias(
 
 local_java_runtime(
     name = "rbe_jdk",
-    java_home = "/usr/lib/jvm/java-11-openjdk-amd64",
-    version = "11.0.21",
+    java_home = "/usr/lib/jvm/java-21-openjdk-amd64",
+    version = "21.0.4",
 )


### PR DESCRIPTION
Fixed and update the container image to use the latest Ubuntu LTS 24.04

Upgrade the java toolchain to use JDK 21 on the container

Adjust the cc toolchain to use the correct import path.
Change compiler type to non-clang to turn off some features. The actual
compiler is still clang
