### PR TITLE
rbe: fix missing pkgs in container image

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update && \
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-      git pkg-config zip unzip rsync patch zsh wget net-tools less parallel locales make \
+      file diffstat git pkg-config zip unzip rsync patch zsh wget net-tools less parallel locales make \
       g++ gcc openjdk-21-jdk openjdk-21-source clang-12 flex asciidoc source-highlight graphviz \
       zlib1g-dev libarchive-dev uuid-dev golang bison \
       ca-certificates-java libsasl2-dev && \

--- a/tools/platforms/configs/rbe_default/config/BUILD
+++ b/tools/platforms/configs/rbe_default/config/BUILD
@@ -43,9 +43,9 @@ platform(
     ],
     exec_properties = {
         # cd tools/docker && \
-        #   docker build -t ghcr.io/sluongng/kythe:20.04 . && \
+        #   docker build --platform=linux/amd64 -t ghcr.io/sluongng/kythe:20.04 . && \
         #   docker push ghcr.io/sluongng/kythe:20.04
-        "container-image": "docker://ghcr.io/sluongng/kythe:20.04@sha256:3bdaef8649058bf4459c5a8f7426c3f939abee8b95dc7beb82951b5d17f3bb78",
+        "container-image": "docker://ghcr.io/sluongng/kythe:20.04@sha256:9337d967836dae793edb8e9544ae12ad44abd1486def51d72cfb9623d5fde16a",
         "OSFamily": "Linux",
     },
 )


### PR DESCRIPTION
file and diffstat are used in some tests' bash script templates.

Also be explicit about the container target platform in the docker
build command
