### PR TITLE
Bump release version

### DIFF
--- a/kythe/release/BUILD
+++ b/kythe/release/BUILD
@@ -22,7 +22,7 @@ docker_build(
     deps = ["//kythe/release/base"],
 )
 
-release_version = "v0.0.68"
+release_version = "v0.0.74-buildbuddy"
 
 genrule(
     name = "release",


### PR DESCRIPTION
Currently the latest release is https://github.com/buildbuddy-io/kythe/releases/tag/v0.0.73
Bumping the release version to v0.0.74 accordingly.
Added a -buildbuddy suffix to indicate this is buildbuddy own version.
