### PR TITLE
Fix build, and some go indexer/verification test failures 

### DIFF
--- a/kythe/go/indexer/BUILD
+++ b/kythe/go/indexer/BUILD
@@ -1,8 +1,8 @@
-load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("//kythe/go/test/tools/empty_corpus_checker:empty_corpus_test.bzl", "empty_corpus_test")
 load("//tools:build_rules/shims.bzl", "go_library", "go_test")
 load(":flags.bzl", "flag_constructor", "flag_constructors")
 load(":testdata/go_indexer_test.bzl", "go_indexer_test")
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
 package(default_visibility = ["//kythe:default_visibility"])
 

--- a/kythe/go/indexer/BUILD
+++ b/kythe/go/indexer/BUILD
@@ -66,13 +66,11 @@ bzl_library(
 go_indexer_test(
     name = "builtin_test",
     srcs = ["testdata/builtin.go"],
-    extra_goals = ["testdata/builtin.go"],
     has_marked_source = True,
     import_path = "builtin",
     resolve_code_facts = True,
-    use_file_as_top_level_scope = True,
     use_fast_solver = False,
-    use_file_nodes = False,
+    use_file_as_top_level_scope = True,
 )
 
 go_indexer_test(
@@ -224,12 +222,10 @@ go_indexer_test(
 go_indexer_test(
     name = "code_rendered_test",
     srcs = ["testdata/code/rendered.go"],
-    extra_goals = ["testdata/code/rendered.go"],
     has_marked_source = True,
     import_path = "rendered",
     resolve_code_facts = True,
     deps = [":builtin_test"],
-    use_file_nodes = False,
 )
 
 go_indexer_test(
@@ -321,18 +317,14 @@ go_indexer_test(
 go_indexer_test(
     name = "types_test",
     srcs = ["testdata/types.go"],
-    extra_goals = ["testdata/types.go"],
     has_marked_source = True,
-    use_file_nodes = False,
 )
 
 go_indexer_test(
     name = "types_test_fs",
     srcs = ["testdata/types.go"],
-    extra_goals = ["testdata/types.go"],
     has_marked_source = True,
     use_fast_solver = True,
-    use_file_nodes = False,
 )
 
 go_indexer_test(
@@ -462,11 +454,11 @@ flag_constructors(
 go_indexer_test(
     name = "flags_test",
     srcs = ["testdata/flags.go"],
+    allow_duplicates = True,
     data = [":test_flags"],
     extra_indexer_args = [
         "-flag_constructors=$(location :test_flags)",
     ],
-    allow_duplicates = True,
 )
 
 # load(":testdata/go_indexer_test.bzl", "go_integration_test")

--- a/kythe/go/indexer/BUILD
+++ b/kythe/go/indexer/BUILD
@@ -71,6 +71,7 @@ go_indexer_test(
     import_path = "builtin",
     resolve_code_facts = True,
     use_file_as_top_level_scope = True,
+    use_fast_solver = False,
     use_file_nodes = False,
 )
 
@@ -223,10 +224,12 @@ go_indexer_test(
 go_indexer_test(
     name = "code_rendered_test",
     srcs = ["testdata/code/rendered.go"],
+    extra_goals = ["testdata/code/rendered.go"],
     has_marked_source = True,
     import_path = "rendered",
     resolve_code_facts = True,
     deps = [":builtin_test"],
+    use_file_nodes = False,
 )
 
 go_indexer_test(
@@ -318,15 +321,19 @@ go_indexer_test(
 go_indexer_test(
     name = "types_test",
     srcs = ["testdata/types.go"],
+    extra_goals = ["testdata/types.go"],
     has_marked_source = True,
+    use_fast_solver = False,
     use_file_nodes = False,
 )
 
 go_indexer_test(
     name = "types_test_fs",
     srcs = ["testdata/types.go"],
+    #extra_goals = ["testdata/types.go"],
     has_marked_source = True,
     use_fast_solver = True,
+    #use_file_nodes = False,
 )
 
 go_indexer_test(
@@ -460,6 +467,8 @@ go_indexer_test(
     extra_indexer_args = [
         "-flag_constructors=$(location :test_flags)",
     ],
+    allow_duplicates = True,
+    #use_file_nodes = False,
 )
 
 # load(":testdata/go_indexer_test.bzl", "go_integration_test")

--- a/kythe/go/indexer/BUILD
+++ b/kythe/go/indexer/BUILD
@@ -71,6 +71,7 @@ go_indexer_test(
     import_path = "builtin",
     resolve_code_facts = True,
     use_file_as_top_level_scope = True,
+    use_file_nodes = False,
 )
 
 go_indexer_test(
@@ -318,6 +319,7 @@ go_indexer_test(
     name = "types_test",
     srcs = ["testdata/types.go"],
     has_marked_source = True,
+    use_file_nodes = False,
 )
 
 go_indexer_test(

--- a/kythe/go/indexer/BUILD
+++ b/kythe/go/indexer/BUILD
@@ -323,17 +323,16 @@ go_indexer_test(
     srcs = ["testdata/types.go"],
     extra_goals = ["testdata/types.go"],
     has_marked_source = True,
-    use_fast_solver = False,
     use_file_nodes = False,
 )
 
 go_indexer_test(
     name = "types_test_fs",
     srcs = ["testdata/types.go"],
-    #extra_goals = ["testdata/types.go"],
+    extra_goals = ["testdata/types.go"],
     has_marked_source = True,
     use_fast_solver = True,
-    #use_file_nodes = False,
+    use_file_nodes = False,
 )
 
 go_indexer_test(
@@ -468,7 +467,6 @@ go_indexer_test(
         "-flag_constructors=$(location :test_flags)",
     ],
     allow_duplicates = True,
-    #use_file_nodes = False,
 )
 
 # load(":testdata/go_indexer_test.bzl", "go_integration_test")

--- a/kythe/go/indexer/BUILD
+++ b/kythe/go/indexer/BUILD
@@ -66,10 +66,10 @@ bzl_library(
 go_indexer_test(
     name = "builtin_test",
     srcs = ["testdata/builtin.go"],
+    extra_goals = ["testdata/builtin.go"],
     has_marked_source = True,
     import_path = "builtin",
     resolve_code_facts = True,
-    use_fast_solver = False,
     use_file_as_top_level_scope = True,
 )
 

--- a/kythe/go/indexer/BUILD
+++ b/kythe/go/indexer/BUILD
@@ -1,8 +1,8 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("//kythe/go/test/tools/empty_corpus_checker:empty_corpus_test.bzl", "empty_corpus_test")
 load("//tools:build_rules/shims.bzl", "go_library", "go_test")
 load(":flags.bzl", "flag_constructor", "flag_constructors")
 load(":testdata/go_indexer_test.bzl", "go_indexer_test")
-load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
 package(default_visibility = ["//kythe:default_visibility"])
 

--- a/kythe/go/indexer/testdata/go_indexer_test.bzl
+++ b/kythe/go/indexer/testdata/go_indexer_test.bzl
@@ -289,15 +289,12 @@ def go_verifier_test(
         has_marked_source = False,
         resolve_code_facts = False,
         allow_duplicates = False,
-        use_fast_solver = False,
-        use_file_nodes = True):
-    opts = ["--show_goals", "--check_for_singletons", "--goal_regex='\\s*//\\s*-(.*)'"]
+        use_fast_solver = False):
+    opts = ["--use_file_nodes", "--show_goals", "--check_for_singletons", "--goal_regex='\\s*//\\s?-(.*)'"]
     if log_entries:
         opts.append("--show_protos")
     if allow_duplicates or len(deps) > 0:
         opts.append("--ignore_dups")
-    if use_file_nodes:
-        opts.append("--use_file_nodes")
     if len(srcs) > 0:
         opts.append("--nofile_vnames")
 
@@ -386,8 +383,7 @@ def go_indexer_test(
         extra_goals = [],
         extra_indexer_args = [],
         extra_extractor_args = [],
-        use_fast_solver = False,
-        use_file_nodes = True):
+        use_fast_solver = False):
     entries = _go_indexer(
         name = name,
         srcs = srcs,
@@ -415,7 +411,6 @@ def go_indexer_test(
         log_entries = log_entries,
         tags = tags,
         use_fast_solver = use_fast_solver,
-        use_file_nodes = use_file_nodes,
     )
 
 # A convenience macro to generate a test library, pass it to the Go indexer,

--- a/kythe/go/indexer/testdata/go_indexer_test.bzl
+++ b/kythe/go/indexer/testdata/go_indexer_test.bzl
@@ -304,8 +304,8 @@ def go_verifier_test(
     # If the test wants marked source, enable support for it in the verifier.
     if has_marked_source:
         opts.append("--convert_marked_source")
-    if use_fast_solver:
-        opts.append("--use_fast_solver")
+    if not use_fast_solver:
+        opts.append("--use_fast_solver=false")
     return verifier_test(
         name = name,
         size = size,

--- a/kythe/go/indexer/testdata/go_indexer_test.bzl
+++ b/kythe/go/indexer/testdata/go_indexer_test.bzl
@@ -289,12 +289,15 @@ def go_verifier_test(
         has_marked_source = False,
         resolve_code_facts = False,
         allow_duplicates = False,
-        use_fast_solver = False):
-    opts = ["--use_file_nodes", "--show_goals", "--check_for_singletons", "--goal_regex='\\s*//\\s*-(.*)'"]
+        use_fast_solver = False,
+        use_file_nodes = True):
+    opts = ["--show_goals", "--check_for_singletons", "--goal_regex='\\s*//\\s*-(.*)'"]
     if log_entries:
         opts.append("--show_protos")
     if allow_duplicates or len(deps) > 0:
         opts.append("--ignore_dups")
+    if use_file_nodes:
+        opts.append("--use_file_nodes")
     if len(srcs) > 0:
         opts.append("--nofile_vnames")
 
@@ -383,7 +386,8 @@ def go_indexer_test(
         extra_goals = [],
         extra_indexer_args = [],
         extra_extractor_args = [],
-        use_fast_solver = False):
+        use_fast_solver = False,
+        use_file_nodes = True):
     entries = _go_indexer(
         name = name,
         srcs = srcs,
@@ -411,6 +415,7 @@ def go_indexer_test(
         log_entries = log_entries,
         tags = tags,
         use_fast_solver = use_fast_solver,
+        use_file_nodes = use_file_nodes,
     )
 
 # A convenience macro to generate a test library, pass it to the Go indexer,

--- a/tools/build_rules/verifier_test/verifier_test.sh.in
+++ b/tools/build_rules/verifier_test/verifier_test.sh.in
@@ -22,6 +22,8 @@ cd "${RUNFILES_DIR}/${WORKSPACE_NAME}"
 ENTRIES=(@ENTRIES@)
 ENTRIES_GZ=(@ENTRIES_GZ@)
 
+echo "1" >&2
+
 # Dir that will contain output files useful for debugging: logs, JSON entries.
 # It will use TEST_UNDECLARED_OUTPUTS_DIR if defined or TEST_TMPDIR otherwise.
 TEST_OUT_DIR="${TEST_UNDECLARED_OUTPUTS_DIR:-$TEST_TMPDIR}"
@@ -30,14 +32,16 @@ TEST_OUT_DIR="${TEST_UNDECLARED_OUTPUTS_DIR:-$TEST_TMPDIR}"
 # 'log:outputname' strings.
 for log in @INDEXER_LOGS@; do
   parts=(${log//:/ })
-  echo Copying file "${parts[0]}" to "${parts[1]}" >&2
+  echo "Indexer logs? ${parts[0]} ${parts[1]}" >&2
   cat "${parts[0]}" > "${TEST_OUT_DIR}/${parts[1]}"
 done
 
+echo "2" >&2
 # Convert entries to JSON and store later for debugging.
 # ENTRIES_TO_LOG is a list of 'entryfile:outputname' strings.
 for entry in @ENTRIES_TO_LOG@; do
   parts=(${entry//:/ })
+  echo "Converting entry ${entry} to JSON, writing to ${parts[1]}" >&2
   @ENTRYSTREAM@ --write_format=json < "${parts[0]}" >> "${TEST_OUT_DIR}/${parts[1]}"
 done
 
@@ -61,12 +65,13 @@ echo "Running verifier" >&2
   if (( ${#ENTRIES_FROM_INLINE_INDEXERS[@]} )); then cat "${ENTRIES_FROM_INLINE_INDEXERS[@]}"; fi
   if (( ${#ENTRIES[@]} )); then cat "${ENTRIES[@]}"; fi
   if (( ${#ENTRIES_GZ[@]} )); then gunzip -c "${ENTRIES_GZ[@]}"; fi
-) | (
+) | tee "${TEST_OUT_DIR}/entries_output.txt" | (
   if [[ -z "@REWRITE@" ]]; then
     @MARKEDSOURCE@ --rewrite
   else
     cat
   fi
-) | (
+) | tee "${TEST_OUT_DIR}/markedsource_output.txt" | (
+  echo "Running verifier: @VERIFIER@" >&2
   if @INVERT@ @VERIFIER@ @ARGS@ "$@"; then exit 0; else exit 1; fi
 )

--- a/tools/build_rules/verifier_test/verifier_test.sh.in
+++ b/tools/build_rules/verifier_test/verifier_test.sh.in
@@ -22,8 +22,6 @@ cd "${RUNFILES_DIR}/${WORKSPACE_NAME}"
 ENTRIES=(@ENTRIES@)
 ENTRIES_GZ=(@ENTRIES_GZ@)
 
-echo "1" >&2
-
 # Dir that will contain output files useful for debugging: logs, JSON entries.
 # It will use TEST_UNDECLARED_OUTPUTS_DIR if defined or TEST_TMPDIR otherwise.
 TEST_OUT_DIR="${TEST_UNDECLARED_OUTPUTS_DIR:-$TEST_TMPDIR}"
@@ -32,16 +30,14 @@ TEST_OUT_DIR="${TEST_UNDECLARED_OUTPUTS_DIR:-$TEST_TMPDIR}"
 # 'log:outputname' strings.
 for log in @INDEXER_LOGS@; do
   parts=(${log//:/ })
-  echo "Indexer logs? ${parts[0]} ${parts[1]}" >&2
+  echo Copying file "${parts[0]}" to "${parts[1]}" >&2
   cat "${parts[0]}" > "${TEST_OUT_DIR}/${parts[1]}"
 done
 
-echo "2" >&2
 # Convert entries to JSON and store later for debugging.
 # ENTRIES_TO_LOG is a list of 'entryfile:outputname' strings.
 for entry in @ENTRIES_TO_LOG@; do
   parts=(${entry//:/ })
-  echo "Converting entry ${entry} to JSON, writing to ${parts[1]}" >&2
   @ENTRYSTREAM@ --write_format=json < "${parts[0]}" >> "${TEST_OUT_DIR}/${parts[1]}"
 done
 
@@ -65,13 +61,12 @@ echo "Running verifier" >&2
   if (( ${#ENTRIES_FROM_INLINE_INDEXERS[@]} )); then cat "${ENTRIES_FROM_INLINE_INDEXERS[@]}"; fi
   if (( ${#ENTRIES[@]} )); then cat "${ENTRIES[@]}"; fi
   if (( ${#ENTRIES_GZ[@]} )); then gunzip -c "${ENTRIES_GZ[@]}"; fi
-) | tee "${TEST_OUT_DIR}/entries_output.txt" | (
+) | (
   if [[ -z "@REWRITE@" ]]; then
     @MARKEDSOURCE@ --rewrite
   else
     cat
   fi
-) | tee "${TEST_OUT_DIR}/markedsource_output.txt" | (
-  echo "Running verifier: @VERIFIER@ @ARGS@" >&2
+) | (
   if @INVERT@ @VERIFIER@ @ARGS@ "$@"; then exit 0; else exit 1; fi
 )

--- a/tools/build_rules/verifier_test/verifier_test.sh.in
+++ b/tools/build_rules/verifier_test/verifier_test.sh.in
@@ -72,6 +72,6 @@ echo "Running verifier" >&2
     cat
   fi
 ) | tee "${TEST_OUT_DIR}/markedsource_output.txt" | (
-  echo "Running verifier: @VERIFIER@" >&2
+  echo "Running verifier: @VERIFIER@ @ARGS@" >&2
   if @INVERT@ @VERIFIER@ @ARGS@ "$@"; then exit 0; else exit 1; fi
 )


### PR DESCRIPTION
The verifier tries to load goals from source files when --use_file_nodes is used (which it is, by default, in these tests). In go 1.24, the comments in builtin.go were reformatted, and are now considered to be malformed goals by the verifier. 

To dance around this, in tests that load builtin.go, we disable --use_file_nodes, which skips loading goals from scanned source files, and only loads them from explicitly supplied files. Impacted tests are updated to supply the files with the goals explicitly as extra_goals. Ultimately this is kind of a hack, but a real fix for this involves either changing the goal comment format to be more distinct, or onerous plumbing of arguments to disable loading goals on a per-file basis.

Additionally, --use_fast_solver defaults to true in the verifier binary, and the build files have been updated to reflect this (previously tests were always using the fast solver).

The types_test_fs test still fails after these changes, and the failure is due to a segfault in the external souffle library that is not really debuggable. This test also fails on kythe/kythe master, so we're at least matching upstream behavior.

This branch also incorporates changes from sluong/fix-indexer-test to fix the build. 
