### PR TITLE
MacOS fixes

### DIFF
--- a/external.bzl
+++ b/external.bzl
@@ -108,9 +108,9 @@ def _cc_dependencies():
         http_archive,
         name = "org_sourceware_libffi",
         build_file = "@io_kythe//third_party:libffi.BUILD",
-        sha256 = "653ffdfc67fbb865f39c7e5df2a071c0beb17206ebfb0a9ecb18a18f63f6b263",  # 2019-11-02
-        strip_prefix = "libffi-3.3-rc2",
-        urls = ["https://github.com/libffi/libffi/releases/download/v3.3-rc2/libffi-3.3-rc2.tar.gz"],
+        sha256 = "bc9842a18898bfacb0ed1252c4febcc7e78fa139fd27fdc7a3e30d9d9356119b",  # 2025-10-04
+        strip_prefix = "libffi-3.4.8",
+        urls = ["https://github.com/libffi/libffi/releases/download/v3.4.8/libffi-3.4.8.tar.gz"],
     )
 
     maybe(

--- a/kythe/go/indexer/testdata/go_indexer_test.bzl
+++ b/kythe/go/indexer/testdata/go_indexer_test.bzl
@@ -151,7 +151,7 @@ go_extract = rule(
         ),
         "_sdk_files": attr.label(
             allow_files = True,
-            default = "@go_sdk_linux//:files",
+            default = "//third_party:go_sdk_files",
         ),
         "extra_extractor_args": attr.string_list(),
     },

--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -68,3 +68,12 @@ alias(
     name = "gmock_main",
     actual = "@com_google_googletest//:gtest_main",
 )
+
+alias(
+    name = "go_sdk_files",
+    actual = select({
+        "@io_bazel_rules_go//go/platform:darwin":  "@go_sdk_darwin_arm64//:files",
+        "//conditions:default": "@go_sdk_linux//:files",
+    }),
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
This includes 2 commits added to fix build on MacOS

```
commit 8cfd7669164619513c318f8c00685c07f17017a5 (HEAD -> sluongng/macos-fixes)
Author: Son Luong Ngoc <sluongng@gmail.com>
Date:   Thu May 29 09:09:58 2025 +0200

    go_indexer_test: select the correct go_sdk files

    Create an alias for go_sdk_files based on the target OS.
    Default to arm64 when it's MacOS and amd64 when it's Linux.

commit e07e215f611e5b5bf30f0bb87e61e373f2332928
Author: Son Luong Ngoc <sluongng@gmail.com>
Date:   Thu May 29 09:07:44 2025 +0200

    external.bzl: upgrade libffi

    This includes a fix to MacOS ARM64 compilation.
    https://github.com/libffi/libffi/issues/908
    https://github.com/libffi/libffi/pull/857

    This does not fully unblock running tests on MacOS, but should at least
    enable some binaries to build successfully.
```
