### PR TITLE
Fix go vnames and bump version

### DIFF
--- a/kythe/data/vnames.go.json
+++ b/kythe/data/vnames.go.json
@@ -39,6 +39,7 @@
   {
     "pattern": "bazel-out/[^/]+/([^/]+)/(.*\\.go)$",
     "vname": {
+      "corpus": "CORPUS",
       "root": "bazel-out/@1@",
       "path": "@2@"
     }
@@ -46,6 +47,7 @@
   {
     "pattern": "bazel-out/[^/]+/([^/]+)/(.*)\\.[xa]$",
     "vname": {
+      "corpus": "CORPUS",
       "root": "bazel-out/@1@",
       "path": "@2@"
     }

--- a/kythe/release/BUILD
+++ b/kythe/release/BUILD
@@ -22,7 +22,7 @@ docker_build(
     deps = ["//kythe/release/base"],
 )
 
-release_version = "v0.0.75-buildbuddy"
+release_version = "v0.0.76-buildbuddy"
 
 genrule(
     name = "release",


### PR DESCRIPTION
The last 2 rules in vnames.go should include the corpus name - these rules match internal files/libs, and so should get the workspace corpus.

This fixes the problem with vname references not lining up across go files within a repository.