### PR TITLE
Use a hardcoded, buildbuddy-specific corpus for vnames

### DIFF
--- a/kythe/data/vnames.go.json
+++ b/kythe/data/vnames.go.json
@@ -39,7 +39,7 @@
   {
     "pattern": "bazel-out/[^/]+/([^/]+)/(.*\\.go)$",
     "vname": {
-      "corpus": "CORPUS",
+      "corpus": "buildbuddy",
       "root": "bazel-out/@1@",
       "path": "@2@"
     }
@@ -47,7 +47,7 @@
   {
     "pattern": "bazel-out/[^/]+/([^/]+)/(.*)\\.[xa]$",
     "vname": {
-      "corpus": "CORPUS",
+      "corpus": "buildbuddy",
       "root": "bazel-out/@1@",
       "path": "@2@"
     }

--- a/kythe/data/vnames.java.json
+++ b/kythe/data/vnames.java.json
@@ -17,21 +17,21 @@
   {
     "pattern": "bazel-out/[^/]+/bin/([^/]+/javatests/.+/testdata)/.+\\.jar!/([^\\$]+)(\\$.+)?\\.class",
     "vname": {
-      "corpus": "CORPUS",
+      "corpus": "buildbuddy",
       "path": "@1@/@2@.java"
     }
   },
   {
     "pattern": "bazel-out/[^/]+/bin/(.*?/java|javatests)/.*\\.jar!/([^\\$]+)(\\$.+)?\\.class",
     "vname": {
-      "corpus": "CORPUS",
+      "corpus": "buildbuddy",
       "path": "@1@/@2@.java"
     }
   },
   {
     "pattern": "bazel-out/[^/]+/bin/[^/]+/proto/.*\\.jar.files/(.+)?\\.java",
     "vname": {
-      "corpus": "CORPUS",
+      "corpus": "buildbuddy",
       "root": "bazel-out/bin/java",
       "path": "@1@.java"
     }
@@ -39,7 +39,7 @@
   {
     "pattern": "bazel-out/[^/]+/bin/[^/]+/proto/.*\\.jar!/([^\\$]+)(\\$.+)?\\.class",
     "vname": {
-      "corpus": "CORPUS",
+      "corpus": "buildbuddy",
       "root": "bazel-out/bin/java",
       "path": "@1@.java"
     }

--- a/kythe/data/vnames.json
+++ b/kythe/data/vnames.json
@@ -2,7 +2,7 @@
   {
     "pattern": "bazel-out/[^/]+/bin/.*/_virtual_imports/[^/]+/(.*)",
     "vname": {
-      "corpus": "CORPUS",
+      "corpus": "buildbuddy",
       "root": "bazel-out/bin",
       "path": "@1@"
     }
@@ -25,7 +25,7 @@
   {
     "pattern": "bazel-out/[^/]+/(\\w+)/(.*)",
     "vname": {
-      "corpus": "CORPUS",
+      "corpus": "buildbuddy",
       "path": "@2@",
       "root": "bazel-out/@1@"
     }
@@ -33,7 +33,7 @@
   {
     "pattern": "(.+).gen.proto",
     "vname": {
-      "corpus": "CORPUS",
+      "corpus": "buildbuddy",
       "root": "bazel-out/bin",
       "path": "@1@.gen.proto"
     }
@@ -41,7 +41,7 @@
   {
     "pattern": "(.*)",
     "vname": {
-      "corpus": "CORPUS",
+      "corpus": "buildbuddy",
       "path": "@1@"
     }
   }

--- a/kythe/data/vnames.proto.json
+++ b/kythe/data/vnames.proto.json
@@ -2,7 +2,7 @@
   {
     "pattern": "bazel-out/[^/]+/bin/external/([^/]+)/_virtual_imports/[^/]+/(.*)",
     "vname": {
-      "corpus": "CORPUS",
+      "corpus": "buildbuddy",
       "root": "@1@",
       "path": "@2@"
     }


### PR DESCRIPTION
**This change would not be appropriate to upstream.**

When indexing, the corpus defaults to the workspace/module name for the bazel project. Unfortunately, when querying annotations from the frontend, that workspace/module name isn't available, and so looking up file decorations isn't feasible. 

This PR modified the vnames config to use a hardcoded corpus for all internal vnames.