### PR TITLE
Add java vnames rule to make generated code nodes match up

### DIFF
--- a/kythe/data/vnames.java.json
+++ b/kythe/data/vnames.java.json
@@ -29,6 +29,14 @@
     }
   },
   {
+    "pattern": "bazel-out/[^/]+/bin/[^/]+/proto/.*\\.jar.files/(.+)?\\.java",
+    "vname": {
+      "corpus": "CORPUS",
+      "root": "bazel-out/bin/java",
+      "path": "@1@.java"
+    }
+  },
+  {
     "pattern": "bazel-out/[^/]+/bin/[^/]+/proto/.*\\.jar!/([^\\$]+)(\\$.+)?\\.class",
     "vname": {
       "corpus": "CORPUS",


### PR DESCRIPTION
This vname rule catches the proto Java generated code.

I'm not sure if this rule will work universally - the only repo with Java & protos that I've tested with is this one.